### PR TITLE
Allow schemes to appear as domain prefixes

### DIFF
--- a/packages/linkifyjs/src/core/parser.js
+++ b/packages/linkifyjs/src/core/parser.js
@@ -109,6 +109,11 @@ export function init() {
 	makeT(DomainDotTld, tk.HYPHEN, DomainHyphen);
 	makeMultiT(DomainDotTld, tk.domain, Domain);
 
+	// Schemes can also appear at the start of a domain name as well
+	makeT(Scheme, tk.DOT, DomainDot);
+	makeT(Scheme, tk.HYPHEN, DomainHyphen);
+	makeMultiT(Scheme, tk.domain, Domain);
+
 	// Become real URLs after `SLASH` or `COLON NUM SLASH`
 	// Here works with or without scheme:// prefix
 	makeT(DomainDotTld, tk.COLON, DomainDotTldColon);


### PR DESCRIPTION
This allows schemes to additionally appear at the start of a domain, such as:

* http.org
* http-help.org
* http123.org

This will be part of the fix for https://github.com/vector-im/element-web/issues/20720